### PR TITLE
Lowercase all the class name

### DIFF
--- a/plugin/src/gen/mod.rs
+++ b/plugin/src/gen/mod.rs
@@ -359,9 +359,7 @@ impl<'ast> ClassContext<'ast> {
     fn lower_case_class_name(&self) -> String {
         lalrpop_intern::read(|interner| {
             let name_str = interner.data(self.class.name.str);
-            let mut name_chars = name_str.chars();
-            let first_char: char = name_chars.next().unwrap();
-            first_char.to_lowercase().chain(name_chars).collect()
+            name_str.to_lowercase()
         })
     }
 


### PR DESCRIPTION
If you had a class like `GtkWidget` the generated C name was `gtkWidget`, now is `gtkwidget`.
Eventually an attribute for `class` would be needed to specify an name space for compatibility reasons. E.g.:

```rust
gobject_gen! {
    // GTK+ doesn't uses `gtkwidget` prefix but uses `gtk_widget`
    #[namespace = "gtk_widget"]
    class GtkWidget { ... }
}
```