### PR TITLE
Use latest lalrpop crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ version = "0.2.1"
 
 # Add a dependency on the LALRPOP runtime library:
 [dependencies.lalrpop-util]
-version = "0.12.5"
+version = "0.13.1"
 
 [build-dependencies.lalrpop]
-version = "0.12.5"
+version = "0.13.1"
 
 [dependencies]
-lalrpop-intern = "0.12.5"
+lalrpop-intern = "0.13.1"
 error-chain = "0.10.0"
 quote = "0.3.15"
 unicode-xid = "0.0.4"


### PR DESCRIPTION
Otherwise, we'll get the older version of petgraph and build fails with
that.